### PR TITLE
`getComputedAttribute` is deprecated. Use `getAttribute` instead

### DIFF
--- a/keyboard-controls.js
+++ b/keyboard-controls.js
@@ -97,7 +97,7 @@ module.exports = {
       velocity[rollAxis] -= velocity[rollAxis] * easing * dt / 1000;
       this.angularVelocity -= this.angularVelocity * easing * dt / 1000;
 
-      var position = el.getComputedAttribute('position');
+      var position = el.getAttribute('position');
 
       if (data.enabled) {
         if (data.pitchAxisEnabled) {


### PR DESCRIPTION
Latest aframe (`master`) deprecated `getComputedAttribute`, and replaced it with the more intuitive `getAttribute`.

More info: https://github.com/aframevr/aframe/pull/1925